### PR TITLE
Allow member to edit themself

### DIFF
--- a/app.js
+++ b/app.js
@@ -181,7 +181,6 @@ app.post('/members/delete/:member', member.delete);
 app.post('/members/reset_password/:member', member.reset_password);
 app.get('/me/change_password', member.change_password_form);
 app.post('/me/change_password', member.change_password);
-app.get('/me', member.edit);
 
 // certifications
 app.get('/members/certifications', certifications.table);

--- a/app.js
+++ b/app.js
@@ -181,7 +181,7 @@ app.post('/members/delete/:member', member.delete);
 app.post('/members/reset_password/:member', member.reset_password);
 app.get('/me/change_password', member.change_password_form);
 app.post('/me/change_password', member.change_password);
-app.get('/me', member.display_self);
+app.get('/me', member.edit);
 
 // certifications
 app.get('/members/certifications', certifications.table);

--- a/routes/member.js
+++ b/routes/member.js
@@ -219,6 +219,11 @@ exports.edit_form = function (req, res) {
 					var edit_account = req.session.member.account.permissions.accounts;
 					var edit_member = req.session.member.account.permissions.members;
 
+					//if the user is viewing themself, let them edit their info
+					if(req.session.member._id == item._id) {
+						edit_member = true;
+					}
+
 					res.render('members/edit', {
 						member: item,
 						edit_account: edit_account,
@@ -419,17 +424,7 @@ exports.change_password = function (req, res) {
 
 exports.display_self = function (req, res) {
 	if (req.session.member) {
-		if (req.session.member.account.permissions.members
-			|| req.session.member.account.permissions.accounts) {
-			res.redirect('/members/edit/' + req.session.member._id);
-		} else {
-			res.render('members/edit', {
-				member: req.session.member,
-				moment: moment,
-				edit_member: false,
-				edit_account: false
-			});
-		}
+		res.redirect('/members/edit/' + req.session.member._id);
 	} else {
 		res.redirect('/');
 	}

--- a/routes/member.js
+++ b/routes/member.js
@@ -220,8 +220,11 @@ exports.edit_form = function (req, res) {
 					var edit_member = req.session.member.account.permissions.members;
 
 					//if the user is viewing themself, let them edit their info
+					//however, if they are not an admin, and not viewing themself, redirect them to the main page
 					if(req.session.member._id == item._id) {
 						edit_member = true;
+					} else if (!edit_account) {
+						return res.redirect('/');
 					}
 
 					res.render('members/edit', {

--- a/routes/member.js
+++ b/routes/member.js
@@ -424,11 +424,3 @@ exports.change_password = function (req, res) {
 		res.redirect('/');
 	}
 };
-
-exports.display_self = function (req, res) {
-	if (req.session.member) {
-		res.redirect('/members/edit/' + req.session.member._id);
-	} else {
-		res.redirect('/');
-	}
-}

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -33,10 +33,7 @@ html(lang="en", itemscope, itemtype="http://schema.org/Organization")
         p
             if authMember
                 span Logged in as 
-                if authMember.account.permissions.accounts || authMember.account.permissions.members
                     a(href='/members/edit/' + authMember._id)= authMember.name.first + ' ' + authMember.name.last
-                else
-                    a(href='/me')= authMember.name.first + ' ' + authMember.name.last
                 span  — 
                 a(href="/me/change_password") Change Password
                 span  — 


### PR DESCRIPTION
display_self now always sends info to edit_form, as long as the viewer is a member. 

edit_form now compares the viewer's member id to the member id of the information, if they are the same, it will set edit_member to true.

The only way a person could view another person's info without the permission is if they type in their id directly into the url (which I tested of course). Should we disable this somehow, since you can still view some potentially sensitive information? They can't change anything of course, but they can view it.