### PR TITLE
Remove fromString() method when creating MongoDB ObjectIds

### DIFF
--- a/routes/application.js
+++ b/routes/application.js
@@ -21,7 +21,7 @@ exports.form = function (req, res) {
 exports.submit = function (req, res) {
 	var Applicant = mongoose.model('Applicant');
 
-	var interview = mongoose.Types.ObjectId.fromString(req.body.interview);
+	var interview = mongoose.Types.ObjectId(req.body.interview);
 
 	new Applicant({
 		name: {
@@ -96,7 +96,7 @@ exports.display_applicant = function (req, res) {
 		req.session.member.account.permissions.members) {
 
 			var Applicant = mongoose.model('Applicant');
-			var id = mongoose.Types.ObjectId.fromString(req.params.id);
+			var id = mongoose.Types.ObjectId(req.params.id);
 
 			Applicant
 				.findOne({_id:id})
@@ -114,7 +114,7 @@ exports.update_applicant = function (req, res) {
 		req.session.member.account.permissions.members) {
 
 			var Applicant = mongoose.model('Applicant');
-			var id = mongoose.Types.ObjectId.fromString(req.params.id);
+			var id = mongoose.Types.ObjectId(req.params.id);
 			Applicant.update({ _id: id }, {
 				interview_notes: req.body.interview_notes
 			}, function (err) {
@@ -130,7 +130,7 @@ exports.migration_form = function (req, res) {
 		req.session.member.account.permissions.members) {
 
 			var Applicant = mongoose.model('Applicant');
-			var id = mongoose.Types.ObjectId.fromString(req.params.id);
+			var id = mongoose.Types.ObjectId(req.params.id);
 			Applicant.findOne({_id: id}, function (err, applicant) {
 				res.render('applicants/migrate', {applicant: applicant});
 			});
@@ -145,7 +145,7 @@ exports.delete_applicant = function (req, res) {
 		req.session.member.account.permissions.members) {
 
 			var Applicant = mongoose.model('Applicant');
-			var id = mongoose.Types.ObjectId.fromString(req.params.id);
+			var id = mongoose.Types.ObjectId(req.params.id);
 
 			Applicant.remove({_id: id}, function (err) {
 				res.redirect('/applicants');
@@ -187,7 +187,7 @@ exports.delete_interview_slot = function (req, res) {
 		req.session.member.account.permissions.members) {
 
 			var Interview = mongoose.model('Interview');
-			var id = mongoose.Types.ObjectId.fromString(req.params.id);
+			var id = mongoose.Types.ObjectId(req.params.id);
 			Interview.remove({ _id: id}, function (err) {
 				res.json(200, {status: 'done'});
 			});

--- a/routes/certifications.js
+++ b/routes/certifications.js
@@ -20,7 +20,7 @@ exports.get_json = function (req, res) {
 		return res.redirect('/');
 	}
 
-	var id = mongoose.Types.ObjectId.fromString(req.params.member);
+	var id = mongoose.Types.ObjectId(req.params.member);
 
 	var Certification = mongoose.model('Certification');
 	Certification
@@ -57,7 +57,7 @@ exports.create = function (req, res) {
 	}
 
 
-	var id = mongoose.Types.ObjectId.fromString(req.body.member);
+	var id = mongoose.Types.ObjectId(req.body.member);
 
 	var Certification = mongoose.model('Certification');
 
@@ -132,7 +132,7 @@ exports.delete = function (req, res) {
 		return res.json(403, {error: 'not authorized'});
 	}
 
-	var query = { _id: mongoose.Types.ObjectId.fromString(req.body.id) };
+	var query = { _id: mongoose.Types.ObjectId(req.body.id) };
 
 	var Certification = mongoose.model('Certification');
 	Certification.findOne(query).remove(function (err) {

--- a/routes/emails.js
+++ b/routes/emails.js
@@ -16,7 +16,7 @@ exports.get_json = function (req, res) {
 		return res.redirect('/');
 	}
 
-	var id = mongoose.Types.ObjectId.fromString(req.params.member);
+	var id = mongoose.Types.ObjectId(req.params.member);
 
 	var Email = mongoose.model('Email');
 	Email.find( {_member: id}, 'address mobile confirmed', function (err, items) {
@@ -108,7 +108,7 @@ exports.delete = function (req, res) {
 	}
 
 	var query = {
-		_id: mongoose.Types.ObjectId.fromString(req.body.id),
+		_id: mongoose.Types.ObjectId(req.body.id),
 		_member: req.session.member._id
 	};
 
@@ -127,7 +127,7 @@ exports.confirm = function (req, res) {
 	if (req.session.member) {
 
 		var query = {
-			_id: mongoose.Types.ObjectId.fromString(req.body.id),
+			_id: mongoose.Types.ObjectId(req.body.id),
 			_member: req.session.member._id,
 			confirm_code: req.body.code
 		};

--- a/routes/member.js
+++ b/routes/member.js
@@ -209,7 +209,7 @@ exports.create = function (req, res) {
 exports.edit_form = function (req, res) {
 	var Member = mongoose.model('Member');
 	Member
-		.findOne({ _id: mongoose.Types.ObjectId.fromString(req.params.member) })
+		.findOne({ _id: mongoose.Types.ObjectId(req.params.member) })
 		.exec(function (err, item) {
 			if (err) {
 				return res.json(404, {error: 'No such member'});
@@ -299,7 +299,7 @@ exports.edit = function (req, res) {
 
 	var both = jsonConcat(account, member);
 
-	var id = mongoose.Types.ObjectId.fromString(req.params.member);
+	var id = mongoose.Types.ObjectId(req.params.member);
 	var update;
 
 	if (req.session.member != undefined) {
@@ -328,7 +328,7 @@ exports.reset_password = function (req, res) {
 	if (req.session.member) {
 		if (req.session.member.account.permissions.accounts) {
 
-			var id = mongoose.Types.ObjectId.fromString(req.params.member);
+			var id = mongoose.Types.ObjectId(req.params.member);
 			var Member = mongoose.model('Member');
 
 			crypto.randomBytes(134, function (ex, salt) {
@@ -369,7 +369,7 @@ exports.delete = function (req, res) {
 	var Email = mongoose.model('Email');
 	var ServiceCredit = mongoose.model('ServiceCredit');
 
-	var id = mongoose.Types.ObjectId.fromString(req.params.member);
+	var id = mongoose.Types.ObjectId(req.params.member);
 
 	if (req.session.member && req.session.member.account.permissions.members) {
 		Member.remove({ _id: id }, function (err) {

--- a/routes/pages.js
+++ b/routes/pages.js
@@ -76,7 +76,7 @@ exports.edit_form = function (req, res) {
 		&& req.session.member.account.permissions.pages) {
 
 		var Page = mongoose.model('Page');
-		var id = mongoose.Types.ObjectId.fromString(req.params.page);
+		var id = mongoose.Types.ObjectId(req.params.page);
 		Page.findOne({_id: id}, function (err, page) {
 			res.render('pages/edit', {page: page});
 		});
@@ -91,7 +91,7 @@ exports.edit = function (req, res) {
 		&& req.session.member.account.permissions.pages) {
 
 		var Page = mongoose.model('Page');
-		var id = mongoose.Types.ObjectId.fromString(req.params.page);
+		var id = mongoose.Types.ObjectId(req.params.page);
 		Page.update({ _id: id }, {
 			name: req.body.name,
 			show_in_nav: (req.body.show_in_nav == 'true')? true : false,
@@ -150,7 +150,7 @@ exports.delete = function (req, res) {
 		&& req.session.member.account.permissions.pages) {
 
 		var Page = mongoose.model('Page');
-		var id = mongoose.Types.ObjectId.fromString(req.params.page);
+		var id = mongoose.Types.ObjectId(req.params.page);
 		Page.remove({ _id: id}, function (err) {
 			res.json(200, {status: 'ok'});
 		});

--- a/routes/schedule.js
+++ b/routes/schedule.js
@@ -208,7 +208,7 @@ exports.create_shift = function (req, res) {
 			var Shift = mongoose.model('Shift');
 
 			if (req.session.member.account.permissions.schedule) {
-				var id = mongoose.Types.ObjectId.fromString(req.body.member);
+				var id = mongoose.Types.ObjectId(req.body.member);
 
 				var Member = mongoose.model('Member');
 				Member.findOne({_id: id}, function (err, member) {
@@ -286,19 +286,19 @@ exports.delete_shift = function (req, res) {
 		// schedulers can remove anyone's shift
 		if (req.session.member.account.permissions.schedule) {
 			Shift.findOne({
-				_id: mongoose.Types.ObjectId.fromString(req.params.shift_id)
+				_id: mongoose.Types.ObjectId(req.params.shift_id)
 			}).remove(function (err) {
 				res.json(200, {status: 'complete'});
 			});
 		} else {
 			Shift.findOne({
-				_id: mongoose.Types.ObjectId.fromString(req.params.shift_id),
+				_id: mongoose.Types.ObjectId(req.params.shift_id),
 				_member: req.session.member._id
 			}, function (err, shift) {
 
 				if (momentIsEditable( moment(shift.start) )) {
 					Shift.remove({
-						_id: mongoose.Types.ObjectId.fromString(req.params.shift_id),
+						_id: mongoose.Types.ObjectId(req.params.shift_id),
 						_member: req.session.member._id
 					}, function (err) {
 						res.json(200, {status: "complete"});
@@ -319,11 +319,11 @@ exports.update_shift = function (req, res) {
 		var search;
 		if (req.session.member.account.permissions.schedule) {
 			search = { 
-				_id: mongoose.Types.ObjectId.fromString(req.params.shift_id)
+				_id: mongoose.Types.ObjectId(req.params.shift_id)
 			};
 		} else {
 			search = { 
-				_id: mongoose.Types.ObjectId.fromString(req.params.shift_id),
+				_id: mongoose.Types.ObjectId(req.params.shift_id),
 				_member: req.session.member._id
 			};
 		}
@@ -359,7 +359,7 @@ exports.get_shift = function (req, res) {
 
 	if (req.session.member) {
 		var Shift = mongoose.model('Shift');
-		Shift.findOne({ _id: mongoose.Types.ObjectId.fromString(req.params.shift_id)}, function (err, item) {
+		Shift.findOne({ _id: mongoose.Types.ObjectId(req.params.shift_id)}, function (err, item) {
 			if (err) {
 				res.json(500, {error: err});
 			} else {
@@ -396,7 +396,7 @@ exports.member_shifts = function (req, res) {
 
 	if (req.session.member) {
 
-		var id = mongoose.Types.ObjectId.fromString(req.params.member);
+		var id = mongoose.Types.ObjectId(req.params.member);
 		if (req.session.member.account.permissions.members
 			|| req.session.member.account.permissions.accounts
 			|| req.session.member._id == id) {
@@ -424,7 +424,7 @@ exports.member_hours_json = function (req, res) {
 
 	if (req.session.member) {
 
-		var id = mongoose.Types.ObjectId.fromString(req.params.member);
+		var id = mongoose.Types.ObjectId(req.params.member);
 		if (req.session.member.account.permissions.members
 			|| req.session.member.account.permissions.accounts
 			|| req.session.member._id == id) {
@@ -524,8 +524,8 @@ exports.future_shift_ics = function (req, res) {
 
 	if (req.session.member) {
 
-		var member = mongoose.Types.ObjectId.fromString(req.params.member);
-		var id = mongoose.Types.ObjectId.fromString(req.params.id);
+		var member = mongoose.Types.ObjectId(req.params.member);
+		var id = mongoose.Types.ObjectId(req.params.id);
 
 		if (req.session.member.account.permissions.members
 			|| req.session.member.account.permissions.accounts

--- a/routes/service_credits.js
+++ b/routes/service_credits.js
@@ -35,7 +35,7 @@ exports.json = function (req, res) {
 			return res.json(403, {});
 		}
 
-		var id = mongoose.Types.ObjectId.fromString(req.params.member);
+		var id = mongoose.Types.ObjectId(req.params.member);
 
 		var ServiceCredit = mongoose.model('ServiceCredit');
 		ServiceCredit
@@ -109,7 +109,7 @@ exports.approve = function (req, res) {
 	if (req.session.member
 		&& req.session.member.account.permissions.service_credit) {
 
-		var id = mongoose.Types.ObjectId.fromString(req.params.credit);
+		var id = mongoose.Types.ObjectId(req.params.credit);
 
 		var ServiceCredit = mongoose.model('ServiceCredit');
 		ServiceCredit.update( { _id: id }, {
@@ -128,7 +128,7 @@ exports.reject = function (req, res) {
 	if (req.session.member
 		&& req.session.member.account.permissions.service_credit) {
 
-		var id = mongoose.Types.ObjectId.fromString(req.params.credit);
+		var id = mongoose.Types.ObjectId(req.params.credit);
 
 		var ServiceCredit = mongoose.model('ServiceCredit');
 		ServiceCredit.remove({ _id: id }, function (err) {


### PR DESCRIPTION
This has apparently been deprecated. Now ObjectIDs are created by simply passing a value to ObjectId itself.