### PR TITLE
Don't send broadcasts to empty emails

### DIFF
--- a/routes/broadcast.js
+++ b/routes/broadcast.js
@@ -34,8 +34,10 @@ exports.send = function (req, res) {
 			// now get school_emails
 			var Member = mongoose.model('Member');
 			Member.find()
-				.where('school_email').ne(null)
-				.select('school_email')
+				.and([
+					{ 'school_email': { '$ne': null } },
+					{ 'school_email': { '$ne': '' } }
+				])
 				.exec(function (err, emails) {
 					emails.forEach(function(email) {
 						fullRecipients.push(email.school_email);


### PR DESCRIPTION
In certain situations, a member's school email could simply be an empty
string. We don't want to try to send to those addresses, so filter them
out.